### PR TITLE
Add guides

### DIFF
--- a/app/_layouts/product.njk
+++ b/app/_layouts/product.njk
@@ -64,6 +64,21 @@
         {% endfor %}
       {% endfor %}
 
+      <div class="govuk-grid-column-full">
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+        {% for item in collections.all | eleventyNavigation(options.homeKey) %}
+          {% if ("Guide" == item.title)  %}
+            <h3 class="govuk-heading-m govuk-!-margin-bottom-1">
+              <a href="{{ item.url | pretty }}">{{ item.title }}</a>
+            </h3>
+            <p class="govuk-body">{{ item.excerpt }}</p>
+          {% endif %}
+        {% endfor %}
+
+
+      </div>
+
     {% endif %}
   </div>
 {% endblock %}

--- a/app/guide.md
+++ b/app/guide.md
@@ -1,0 +1,10 @@
+---
+layout: collection
+title: Guide
+description: About this design history and how to publish to it
+pagination:
+  data: collections.guide
+  reverse: false
+  size: 50
+permalink: "guide/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% endif %}/"
+---

--- a/app/guide/how-to-publish.md
+++ b/app/guide/how-to-publish.md
@@ -10,7 +10,7 @@ To contribute you will need a free GitHub account, and for your account to be ad
 Once this is done, these steps:
 
 1. Create a branch. The name of the branch doesn’t matter too much but you could name it after your post title.
-2. Add a new markdown file in `app/posts/[service-name]/YYYY/MM/[post-name].md`. It's often easier to duplicate an existing post as that will have the headers you need.
+2. Add a new markdown file in `app/posts/[service-name]/YYYY/MM/[post-name].md`. It’s often easier to duplicate an existing post. That way, you will have the headers that contain basic information that all posts need.
 3. Edit the post with your content - make sure it has a title and date.
 4. If you have images, add them to a folder in `app/images/[service-name]/YYYY/MM/[post-name]/`.
 5. Open a pull request with your changes and ask for someone to review it. A preview will be available linked from the pull request.

--- a/app/guide/how-to-publish.md
+++ b/app/guide/how-to-publish.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: How to publish a design history entry
+---
+
+Publishing a design history entry currently requires a bit of familiarity with [GitHub](https://github.com) and [Markdown](https://www.markdownguide.org), but we can help you if needed.
+
+To contribute you will need a free GitHub account, and for your account to be added to this project.
+
+Once this is done, you should follow these steps:
+
+1. Create a branch. The name of the branch doesn’t matter too much but you could name it after your post title.
+2. Add a new markdown file in `app/posts/[service-name]/YYYY/MM/[post-name].md`. It's often easier to duplicate an existing post as that will have the headers you need.
+3. Edit the post with your content - make sure it has a title and date.
+4. If you have images, add them to a folder in `app/images/[service-name]/YYYY/MM/[post-name]/`.
+5. Open a pull request with your changes and ask for someone to review it. A preview will be available linked from the pull request.
+6. Once it’s reviewed, you can merge the pull request and the post will appear live within a minute or so.

--- a/app/guide/how-to-publish.md
+++ b/app/guide/how-to-publish.md
@@ -1,6 +1,9 @@
 ---
 layout: page
 title: How to publish a design history entry
+description: A guide for our teams on how to publish to this site.
+eleventyNavigation:
+  parent: Guide
 ---
 
 To publish a design history post, you need to use [GitHub](https://github.com) and [Markdown](https://www.markdownguide.org), but we can help you.

--- a/app/guide/how-to-publish.md
+++ b/app/guide/how-to-publish.md
@@ -3,11 +3,11 @@ layout: page
 title: How to publish a design history entry
 ---
 
-Publishing a design history entry currently requires a bit of familiarity with [GitHub](https://github.com) and [Markdown](https://www.markdownguide.org), but we can help you if needed.
+To publish a design history post, you need to use [GitHub](https://github.com) and [Markdown](https://www.markdownguide.org), but we can help you.
 
 To contribute you will need a free GitHub account, and for your account to be added to this project.
 
-Once this is done, you should follow these steps:
+Once this is done, these steps:
 
 1. Create a branch. The name of the branch doesn’t matter too much but you could name it after your post title.
 2. Add a new markdown file in `app/posts/[service-name]/YYYY/MM/[post-name].md`. It's often easier to duplicate an existing post as that will have the headers you need.

--- a/app/guide/how-to-publish.md
+++ b/app/guide/how-to-publish.md
@@ -14,7 +14,7 @@ Once this is done, these steps:
 
 1. Create a branch. The name of the branch doesn’t matter too much but you could name it after your post title.
 2. Add a new markdown file in `app/posts/[service-name]/YYYY/MM/[post-name].md`. It’s often easier to duplicate an existing post. That way, you will have the headers that contain basic information that all posts need.
-3. Edit the post with your content - make sure it has a title and date.
+3. Edit the post with your content – make sure it has a title and date.
 4. If you have images, add them to a folder in `app/images/[service-name]/YYYY/MM/[post-name]/`.
 5. Open a pull request with your changes and ask for someone to review it. A preview will be available linked from the pull request.
 6. Once it’s reviewed, you can merge the pull request and the post will appear live within a minute or so.

--- a/app/guide/how-to-publish.md
+++ b/app/guide/how-to-publish.md
@@ -6,7 +6,9 @@ eleventyNavigation:
   parent: Guide
 ---
 
-To publish a design history post, you need to use [GitHub](https://github.com) and [Markdown](https://www.markdownguide.org), but we can help you.
+To publish a design history post, you need to use [GitHub](https://github.com) and [Markdown](https://www.markdownguide.org).
+
+If you need any help with this, ask on the Slack channel – [#dpsp-prof-ucd](https://nhsdigitalcorporate.enterprise.slack.com/archives/C06DGMH1XUN).
 
 To contribute you will need a free GitHub account, and for your account to be added to this project.
 

--- a/app/guide/what-to-include-in-a-design-history.md
+++ b/app/guide/what-to-include-in-a-design-history.md
@@ -1,6 +1,9 @@
 ---
 layout: page
 title: What to include in a design history
+description: Some tips on things to write about.
+eleventyNavigation:
+  parent: Guide
 ---
 
 Most things you do can be shared.

--- a/app/guide/what-to-include-in-a-design-history.md
+++ b/app/guide/what-to-include-in-a-design-history.md
@@ -1,0 +1,23 @@
+---
+layout: page
+title: What to include in a design history
+---
+
+Most things you do can be shared.
+
+You could include:
+
+* anything that's useful to return to later
+* new features, iterations of existing ones, findings from user research
+* old and new designs, highlighting how they've changed and why
+* significant changes
+* ideas you’re trying or that haven’t worked.
+* things that would be useful for others
+
+### What not to include
+
+Do not include personal details of participants or staff.
+
+You don’t need to document evert single decision. You will struggle with time to do this and people probably won’t be interested.
+
+Don’t include anything contentious that in could involve significant detrimental effects to a person or people’s jobs.

--- a/app/guide/what-to-include-in-a-design-history.md
+++ b/app/guide/what-to-include-in-a-design-history.md
@@ -7,11 +7,11 @@ Most things you do can be shared.
 
 You could include:
 
-* anything that's useful to return to later
+* anything that’s useful to return to later
 * new features, iterations of existing ones, findings from user research
 * old and new designs, highlighting how they've changed and why
 * significant changes
-* ideas you’re trying or that haven’t worked.
+* ideas you’re trying or that haven’t worked
 * things that would be useful for others
 
 ### What not to include
@@ -20,4 +20,4 @@ Do not include personal details of participants or staff.
 
 You don’t need to document evert single decision. You will struggle with time to do this and people probably won’t be interested.
 
-Don’t include anything contentious that in could involve significant detrimental effects to a person or people’s jobs.
+Don’t include anything that in could be detrimental to a person or the NHS.

--- a/app/guide/why-we-write-design-histories.md
+++ b/app/guide/why-we-write-design-histories.md
@@ -1,0 +1,24 @@
+---
+layout: page
+title: Why we write design histories
+---
+
+It's easy to forget what’s been done, and why.
+
+Design histories help us remember.
+
+They can:
+
+* show us how a service has changed over time
+* summarise the outcomes from past user research
+* remind why decisions were taken
+* give context to new team members
+* share design patterns with wider teams in the NHS and government
+
+## Designing in the open
+
+Writing design histories supports [designing in the open](https://service-manual.nhs.uk/design-system/design-principles).
+
+It means we are sharing our learning and are transparent in our design decisions.
+
+It is also a way of meeting the NHS Service Standard by [documenting common components and patterns](https://service-manual.nhs.uk/standards-and-technology/service-standard-points/13-use-and-contribute-to-open-standards-common-components-and-patterns) so that others can benefit from our work.

--- a/app/guide/why-we-write-design-histories.md
+++ b/app/guide/why-we-write-design-histories.md
@@ -1,6 +1,9 @@
 ---
 layout: page
 title: Why we write design histories
+description: Writing up design and research work helps our teams to share and remember.
+eleventyNavigation:
+  parent: Guide
 ---
 
 It's easy to forget what’s been done, and why.

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -98,6 +98,10 @@ module.exports = function (eleventyConfig) {
     return collection.getFilteredByGlob('app/posts/smoking-cessation/**/*.md')
   })
 
+  eleventyConfig.addCollection('guide', collection => {
+    return collection.getFilteredByGlob('app/guide/**/*.md')
+  })
+
   // Config
   return {
     dataTemplateEngine: 'njk',


### PR DESCRIPTION
This adds some potential guides, as public pages. Could be linked from the footer or from a new section on homepage.

Possible pages:

* [Why we write design histories](https://screening-de-add-guides-ynh2d1.herokuapp.com/guide/why-we-write-design-histories/)
* [What to include in a design history](https://screening-de-add-guides-ynh2d1.herokuapp.com/guide/what-to-include-in-a-design-history/)
* [How to publish a design history entry](https://screening-de-add-guides-ynh2d1.herokuapp.com/guide/how-to-publish/)

Ideas welcome! The DfE [Becoming a teacher design history](https://becoming-a-teacher.design-history.education.gov.uk/how-to/) has some examples we could re-use.

Thanks to @joe-knowles1 for kicking this off!