### PR TITLE
Add service name to page title tags

### DIFF
--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -2,7 +2,7 @@
 
 {% if eleventyNavigation.parent %}
   {% block pageTitle %}
-    {{- title }} - {{ eleventyNavigation.parent }} - {{ options.titleSuffix }}
+    {{- title }} - {{ eleventyNavigation.parent }} - {{ options.titleSuffix -}}
   {% endblock %}
 {% endif %}
 

--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -1,5 +1,11 @@
 {% extends "layouts/post.njk" %}
 
+{% if eleventyNavigation.parent %}
+  {% block pageTitle %}
+    {{- title }} - {{ eleventyNavigation.parent }} - {{ options.titleSuffix }}
+  {% endblock %}
+{% endif %}
+
 {% from "screenshots/macro.njk" import appScreenshots %}
 
 {% block content %}


### PR DESCRIPTION
This should help to avoid ambiguity when posts are shared elsewhere, and avoid the need to mention the service name in every post title.

Before:

> Modernisation and other work - NHS Digital prevention services design history

After:

> Modernisation and other work - Bowel screening - NHS Digital prevention services design history