### PR TITLE
Add a full width utility class for media

### DIFF
--- a/app/styles/application.scss
+++ b/app/styles/application.scss
@@ -13,4 +13,15 @@
   .nhsuk-image__img {
     padding: nhsuk-spacing(2);
   }
+
+  // Class to allow full-width, breaking out of the grid
+  // add to a lone element (ie img) or a container (ie figure)
+  .app-media--full-width {
+    width: 92vw;
+    max-width: 960px;
+
+    figcaption {
+      max-width: 44em;
+    }
+  }
 }


### PR DESCRIPTION
Allow media such as images to break horizontally out of the grid.

Add to a lone element (ie img) or a container (ie figure) -

```
<figure class="app-media--full-width">
  <img src="prototype-flow.png" alt="Diagram depicting the prototype user journey using sequential screen grabs from left to right.">
  <figcaption>The prototype journey from left to right, from calculator result to a 'finding services' loading screen.</figcaption>
</figure>
```

```
<figure class="app-media--full-width">
  <img src="prototype-flow.png" alt="Diagram depicting the prototype user journey using sequential screen grabs from left to right.">
</figure>
```

The `.app-media--full-width` element with remain at 92vw up to a max of 960px.

<img width="1068" alt="Screenshot showing 2 elements using the new css class, with the main grid container highlighted" src="https://github.com/user-attachments/assets/224ee12f-5c47-41e2-97ff-af03807e3378" />
