### PR TITLE
Specify Node.js version as 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "webshot-node": "^0.18.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": "22.x"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "private": true,
   "engines": {
-    "node": ">=18"
+    "node": "22.x"
   }
 }


### PR DESCRIPTION
This was already specified in `.nvmrc` but `package.json` was specifying `>=18`. This started causing a new error when deploying to Heroku:

```
- Dangerous semver range (>) in engines.node
   https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version
```

Heroku recommend using `22.x` instead.