### PR TITLE
Update NodeJS version in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 16.18.0
+nodejs 22


### PR DESCRIPTION
This is mis-matching the Node version specified in `package.json` - we now require Node 22.

Thanks to @colinrotherham for spotting.