### PR TITLE
Make asdf tool versions exact

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 22
+nodejs 22.0.0


### PR DESCRIPTION
`asdf install` looks for [exact versions](https://asdf-vm.com/guide/getting-started.html#_5-install-a-version)

Without an exact version, we get an error:

```
$ asdf install
Trying to update node-build... ok
node-build: definition not found: 22
failed to run install callback: exit status 2
```