### PR TITLE
Add page for all posts

### DIFF
--- a/app/all.md
+++ b/app/all.md
@@ -1,0 +1,9 @@
+---
+layout: collection
+title: All posts
+pagination:
+  data: collections.post
+  reverse: true
+  size: 50
+permalink: "all/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% endif %}/"
+---

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -28,6 +28,10 @@ export default function (eleventyConfig) {
             href: '/sitemap'
           },
           {
+            text: 'All posts',
+            href: '/all'
+          },
+          {
             text: 'Subscribe to feed',
             href: '/feed.xml'
           },


### PR DESCRIPTION
This makes it possible to browse all posts, in date order.

Resolves #275
