### PR TITLE
Add vaccine tags

### DIFF
--- a/app/book-a-vaccination/2026/preparing-for-end-of-season/index.md
+++ b/app/book-a-vaccination/2026/preparing-for-end-of-season/index.md
@@ -5,6 +5,7 @@ description: How we got ready to close the flu and COVID services
 tags:
   - appointments
   - seasonal changes
+  - COVID-19 vaccine
 author: Jo Lumley
 ---
 

--- a/app/book-a-vaccination/2026/preparing-for-end-of-season/index.md
+++ b/app/book-a-vaccination/2026/preparing-for-end-of-season/index.md
@@ -6,6 +6,7 @@ tags:
   - appointments
   - seasonal changes
   - COVID-19 vaccine
+  - flu vaccine
 author: Jo Lumley
 ---
 

--- a/app/manage-vaccinations-in-schools/2022/11/poc-flu-campaign/index.md
+++ b/app/manage-vaccinations-in-schools/2022/11/poc-flu-campaign/index.md
@@ -14,6 +14,8 @@ screenshots:
     - Child details after vaccination
     - Child details after vaccination refused
     - Updated flu campaign page
+tags:
+  - flu vaccine
 ---
 
 We started with a flu point of care (POC) journey because we:

--- a/app/manage-vaccinations-in-schools/2023/03/consent-for-an-hpv-vaccine-iteration/index.md
+++ b/app/manage-vaccinations-in-schools/2023/03/consent-for-an-hpv-vaccine-iteration/index.md
@@ -23,6 +23,8 @@ screenshots:
     - Anything else?
     - Check answers and confirm
     - Confirmation page
+tags:
+  - HPV vaccine
 ---
 
 Based on user research, we iterated [our initial consent journey for parents](/manage-vaccinations-in-schools/2023/03/consent-for-an-hpv-vaccine/).

--- a/app/manage-vaccinations-in-schools/2023/03/consent-for-an-hpv-vaccine/index.md
+++ b/app/manage-vaccinations-in-schools/2023/03/consent-for-an-hpv-vaccine/index.md
@@ -57,6 +57,8 @@ screenshots:
     - Can we contact you about a catch-up?
     - Check answers and confirm
     - Confirmation page
+tags:
+  - HPV vaccine
 ---
 
 An overview of the journey for parents who are giving consent for their child to receive the HPV vaccine. These are the designs as we built them before our first round of research with parents.

--- a/app/manage-vaccinations-in-schools/2024/12/hpv-consent/index.md
+++ b/app/manage-vaccinations-in-schools/2024/12/hpv-consent/index.md
@@ -58,6 +58,8 @@ screenshots:
         text: Confirmation
       - id: confirmation-consent-given-and-needs-triage
         text: Confirmation (health answers need triage)
+tags:
+  - HPV vaccine
 ---
 
 The following is a snapshot of the parental consent journey as it appeared when the service launched into private beta with Coventry and Warwickshire Partnership NHS Trust on 16 December 2024.

--- a/app/manage-vaccinations-in-schools/2024/12/hpv-operations/index.md
+++ b/app/manage-vaccinations-in-schools/2024/12/hpv-operations/index.md
@@ -70,6 +70,8 @@ screenshots:
         text: Edit batch
       - id: vaccines-batch-archive
         text: Archive batch
+tags:
+  - HPV vaccine
 ---
 
 The following is a snapshot of the operational aspects of Mavis as they appeared when the service launched into private beta with Coventry and Warwickshire Partnership NHS Trust on 16 December 2024.

--- a/app/manage-vaccinations-in-schools/2024/12/hpv-sessions/index.md
+++ b/app/manage-vaccinations-in-schools/2024/12/hpv-sessions/index.md
@@ -86,6 +86,8 @@ screenshots:
         text: Check and confirm
       - id: patient-vaccinated
         text: Confirmation of vaccination recorded
+tags:
+  - HPV vaccine
 ---
 
 The following is a snapshot of session management and recording HPV vaccinations when the service launched into private beta with Coventry and Warwickshire Partnership NHS Trust on 16 December 2024.

--- a/app/manage-vaccinations-in-schools/2025/03/importing-menacwy-vaccination-history-into-mavis/index.md
+++ b/app/manage-vaccinations-in-schools/2025/03/importing-menacwy-vaccination-history-into-mavis/index.md
@@ -1,6 +1,8 @@
 ---
 title: Importing MenACWY vaccination histories into Mavis
 date: 2025-03-25
+tags:
+  - MenACWY vaccine
 ---
 
 This post describes how we adapted Mavis to handle MenACWY vaccination histories and the issues we encountered when working with an early adopter School Age Immunisation Service (SAIS) team and their Child Health Information System (CHIS).

--- a/app/manage-vaccinations-in-schools/2025/04/doubles-consent/index.md
+++ b/app/manage-vaccinations-in-schools/2025/04/doubles-consent/index.md
@@ -74,6 +74,11 @@ screenshots:
         text: Confirmation (consent given for one vaccination)
       - id: confirmation-consent-given-for-one-and-needs-triage
         text: Confirmation (consent given for one vaccination and health answers need triage)
+tags:
+  - MenB vaccine
+  - MenACWY vaccine
+  - Td/IPV vaccine
+  - MMR vaccine
 ---
 
 The first SAIS team to use our service was Coventry and Warwickshire Partnership NHS Trust (CWPT). They run HPV vaccination sessions for year 8 students at the start of the Spring term, before turning their attention to MenACWY and Td/IPV sessions at the start of the Summer term.

--- a/app/manage-vaccinations-in-schools/2025/04/doubles-recording/index.md
+++ b/app/manage-vaccinations-in-schools/2025/04/doubles-recording/index.md
@@ -39,6 +39,9 @@ screenshots:
       - Patient session (vaccinated for all programmes)
       - text: Patient session (not vaccinated)
         caption: We updated the design to ensure that it’s still possible to vaccinate a child if a previous attempt was unsuccessful.
+tags:
+  - MenACWY vaccine
+  - Td/IPV vaccine
 ---
 
 The first SAIS team to use our service was Coventry and Warwickshire Partnership NHS Trust (CWPT). They run HPV vaccination sessions for year 8 students at the start of the Spring term, before turning their attention to MenACWY and Td/IPV sessions at the start of the Summer term.

--- a/app/manage-vaccinations-in-schools/2025/06/flu-health-questions/index.md
+++ b/app/manage-vaccinations-in-schools/2025/06/flu-health-questions/index.md
@@ -1,6 +1,8 @@
 ---
 title: Asking parents the right health questions for flu
 date: 2025-06-17
+tags:
+- flu vaccine
 ---
 
 For the 2025 flu programme, we reviewed the health questions currently asked by SAIS teams, as well as those recommended by the UKHSA.

--- a/app/manage-vaccinations-in-schools/2025/09/flu-consent/index.md
+++ b/app/manage-vaccinations-in-schools/2025/09/flu-consent/index.md
@@ -113,6 +113,8 @@ screenshots:
         text: Confirmation (alternative injection)
       - id: confirmation-consent-given-alternative-and-needs-triage
         text: Confirmation (alternative injection, health answers need triage)
+tags:
+  - flu vaccine
 ---
 
 The children’s flu vaccine is offered yearly to all school-aged children (Reception to Year 11). Sessions run from the beginning of September every year.

--- a/app/manage-vaccinations-in-schools/2025/09/flu-recording/index.md
+++ b/app/manage-vaccinations-in-schools/2025/09/flu-recording/index.md
@@ -38,6 +38,8 @@ screenshots:
         caption: In this example, the parent has given consent for the injected vaccine only. An HCA can administer a vaccine using the national protocol by recording who supplied it.
       - text: Confirm vaccination (HCA, national protocol)
         caption: The confirmation screen for an HCA using the national protocol shows the nurse who supplied the vaccine.
+tags:
+  - flu vaccine
 ---
 
 The children’s flu vaccine is offered yearly to all school-aged children (Reception to Year 11). Sessions run from the beginning of September every year.

--- a/app/record-a-vaccination/2024/06/recording-covid-19-and-flu-together/index.md
+++ b/app/record-a-vaccination/2024/06/recording-covid-19-and-flu-together/index.md
@@ -1,6 +1,9 @@
 ---
 title: Recording COVID-19 and flu together
 date: 2024-06-17
+tags:
+  - flu vaccine
+  - COVID-19 vaccine
 ---
 
 ## Supporting co-administration

--- a/app/record-a-vaccination/2025/12/london-pharmacy-research/index.md
+++ b/app/record-a-vaccination/2025/12/london-pharmacy-research/index.md
@@ -13,8 +13,8 @@ author:
 tags:
   - pharmacies
   - onboarding
-  - flu
-  - COVID-19
+  - flu vaccine
+  - COVID-19 vaccine
 ---
 
 In a cold and snowy November 2025, we visited 13 community pharmacies in London that had recently started using Record a vaccination for the autumn-winter flu and COVID-19 vaccinations campaigns.

--- a/app/record-a-vaccination/2026/04/supporting-menb-vaccinations-in-response-to-an-outbreak/index.md
+++ b/app/record-a-vaccination/2026/04/supporting-menb-vaccinations-in-response-to-an-outbreak/index.md
@@ -3,7 +3,7 @@ title: Supporting MenB vaccinations in response to an outbreak
 description: Changes we made to enable recording of the MenB vaccine
 date: 2026-04-23
 tags:
-  - MenB
+  - MenB vaccine
   - dose sequence
 image:
   src: /record-a-vaccination/2026/04/supporting-menb-vaccinations-in-response-to-an-outbreak/menb.png

--- a/app/vaccinations/2025/10/how-we-responded-to-the-covid-19-booster-confusion/index.md
+++ b/app/vaccinations/2025/10/how-we-responded-to-the-covid-19-booster-confusion/index.md
@@ -2,6 +2,8 @@
 title: How we responded to the COVID-19 booster confusion
 author: Caroline Finucane
 date: 2025-10-23
+tags:
+  - COVID-19 vaccine
 ---
 
 **This autumn, as the COVID-19 vaccination programme launched, our digital services team needed to move quickly to respond to confusion around eligibility.**


### PR DESCRIPTION
This is a quick attempt to try and add vaccine tags (eg "COVID-19 vaccine", "MenB vaccine") consistently to relevant posts.

Hopefully this might make it easier to discover relevant posts about a specific vaccine from across the teams.