### PR TITLE
Passthrough copy svgs

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -59,6 +59,7 @@ export default function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy('./app/**/*.png')
   eleventyConfig.addPassthroughCopy('./app/**/*.pdf')
   eleventyConfig.addPassthroughCopy('./app/**/*.sketch')
+  eleventyConfig.addPassthroughCopy('./app/**/*.svg')
 
   // Nunjucks filters
   eleventyConfig.addFilter('push', (array, item) => {


### PR DESCRIPTION
This is needed to copy svg assets so they can be referenced in posts.