### PR TITLE
Refactor passthrough copy

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -52,14 +52,11 @@ export default function (eleventyConfig) {
   })
 
   // Images and PDFs
-  eleventyConfig.addPassthroughCopy('./app/**/*.ai')
-  eleventyConfig.addPassthroughCopy('./app/**/*.gif')
-  eleventyConfig.addPassthroughCopy('./app/**/*.jpg')
-  eleventyConfig.addPassthroughCopy('./app/**/*.jpeg')
-  eleventyConfig.addPassthroughCopy('./app/**/*.png')
-  eleventyConfig.addPassthroughCopy('./app/**/*.pdf')
-  eleventyConfig.addPassthroughCopy('./app/**/*.sketch')
-  eleventyConfig.addPassthroughCopy('./app/**/*.svg')
+  for (const ext of [
+    'ai', 'avif', 'gif', 'jpg', 'jpeg', 'png', 'pdf', 'sketch', 'svg', 'tiff', 'webp'
+  ]) {
+    eleventyConfig.addPassthroughCopy(`./app/**/*.{${ext},${ext.toUpperCase()}}`)
+  }
 
   // Nunjucks filters
   eleventyConfig.addFilter('push', (array, item) => {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -52,11 +52,9 @@ export default function (eleventyConfig) {
   })
 
   // Images and PDFs
-  for (const ext of [
-    'ai', 'avif', 'gif', 'jpg', 'jpeg', 'png', 'pdf', 'sketch', 'svg', 'tiff', 'webp'
-  ]) {
-    eleventyConfig.addPassthroughCopy(`./app/**/*.{${ext},${ext.toUpperCase()}}`)
-  }
+  const imageAndDocumentExtensions = ['ai', 'avif', 'gif', 'jpg', 'jpeg', 'png', 'pdf', 'sketch', 'svg', 'tiff', 'webp']
+  const allCases = imageAndDocumentExtensions.flatMap((ext) => [ext, ext.toUpperCase()])
+  eleventyConfig.addPassthroughCopy(`./app/**/*.{${allCases.join(',')}}`)
 
   // Nunjucks filters
   eleventyConfig.addFilter('push', (array, item) => {


### PR DESCRIPTION
Reworks the passthrough copy so it's an array of formats (adding `avif`, `tiff`, `webp`) and also supporting uppercase variants.