### PR TITLE
Creating an end-to-end vaccination service demo

### DIFF
--- a/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
+++ b/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
@@ -1,0 +1,35 @@
+---
+title: This is the title of the post
+description: This description will appear on index pages and when sharing on social media.
+date: 2025-12-01
+tags:
+  - add
+  - tags
+  - to help group
+  - related posts
+author:
+  - Your Name
+  - Another Name
+opengraphImage:
+  src: /your-service/2025/12/post-title/image-name.png
+  alt: Alternative text for the lead image
+---
+
+An intro paragraph which summarises the whole thing.
+
+## Heading
+
+Some content.
+
+[A link to another post](/your-service/2025/11/another-post-title/)
+
+### Subheading
+
+More content
+
+![Alt text for an image](/your-service/2025/12/post-title/image.jpg)
+
+This image has a visible caption:
+
+![Alt text for an image](nhs-logo.png "Caption for the image")
+

--- a/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
+++ b/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
@@ -20,6 +20,8 @@ We centred the journey on RSV so we could demonstrate an NHS App feature - [Chec
 
 ## Watch the demo
 
+You can [watch the demo here](<iframe src="https://nhs-my.sharepoint.com/personal/caroline_finucane_nhs_net/_layouts/15/embed.aspx?UniqueId=d7a8c461-d6b6-4acd-9c58-835a4fccd6b9&embed=%7B%22ust%22%3Atrue%2C%22hv%22%3A%22CopyEmbedCode%22%7D&referrer=StreamWebApp&referrerScenario=EmbedDialog.Create" width="640" height="360" frameborder="0" scrolling="no" allowfullscreen title="Rosies_Journey_Mk6.mp4"></iframe>).
+
 We're hoping this narrative might be useful for:
 
 - showing commissioners and stakeholders how our products contribute to a real vaccination journey

--- a/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
+++ b/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
@@ -1,6 +1,6 @@
 ---
-title: "Demo Video: how VDS helps Rosie get vaccinated this autumn"
-description: Why the design team within VDS created an end-to-end demo to make visible how our digital services support the whole journey of getting a vaccination.
+title: "Watch: how VDS helps Rosie get vaccinated this autumn"
+description: How the design team within VDS created an end-to-end demo video showing how their digital services support someone getting a vaccination.
 date: 2026-08-03
 tags:
   - demo video
@@ -10,23 +10,24 @@ author:
   - Caroline Finucane
 ---
 
-Over the past year, teams within Vaccination Digital Services have delivered a lot - but for commissioners, stakeholders, and even people working within DPSP, it's not always clear how those pieces fit together or what value they create in practice. We created an end-to-end demo to make that visible.
+Over the last year, teams across Vaccination Digital Services have delivered new products, features and improvements. But for commissioners, stakeholders and colleagues, it can be difficult to see how those pieces fit together as part of a single vaccination journey. 
 
-This demo video shows how our products come together to support a person getting an RSV and COVID vaccination in one appointment, using the NHS App.
+To help make that visible, we created an end-to-end demo showing how our digital services support someone getting an RSV and COVID vaccination in one appointment using the NHS App.
 
-The aim was to help stakeholders understand how we support real campaigns, and give people a clear view of the system as a whole. We included some upcoming features to show where we’re heading.
+The demo follows a fictional person, Rosie, through the journey from invitation to vaccination. This helped us tell a story about the service as a whole, and show how different products work together to support vaccination campaigns.
 
-We centred the journey on RSV, so we could demonstrate a new NHS App feature - [Check and Book Vaccinations](https://design-history.prevention-services.nhs.uk/vaccinations-in-the-app/) (currently in private beta) - which supports the RSV vaccination service specifically. 
+We centred the journey on RSV so we could demonstrate an NHS App feature - [Check and Book Vaccinations](https://design-history.prevention-services.nhs.uk/vaccinations-in-the-app/), currently in private beta - that offers a more personalised vaccination experience.
+
+## Watch the demo
 
 [Watch the demo video](https://nhs-my.sharepoint.com/:v:/r/personal/caroline_finucane_nhs_net/Documents/Rosies_Journey_Mk6.mp4?csf=1&web=1&e=tPotYr&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D).
 
-It was more effort than expected (thank you, UCD team) - but I'm hoping the result now gives us a stronger way to show:
+We're hoping this narrative might be useful for:
 
-- commissioners what we've delivered
-- new starters and other colleagues what we're working on
-- how our services work as a whole
+- showing commissioners and stakeholders how our products contribute to a real vaccination journey
+- helping new starters understand the VDS ecosystem
+- creating a more engaging alternative to diagrams, slides and product lists
 
-Because, bringing the journey to life through visuals and narrative makes complex systems easier to understand - and is more engaging for the people we need to influence.
-   
+Complex systems are easier to understand when people can see them working in context. By combining visuals, narrative and realistic user scenarios, we hope this demo makes the value of our services easier to understand.   
 
-
+We do not yet know whether this approach is more effective than traditional presentations and documentation, but we'll share what we learn.

--- a/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
+++ b/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
@@ -22,12 +22,12 @@ We centred the journey on RSV so we could demonstrate an NHS App feature - [Chec
 
 You can [watch the demo here](<iframe src="https://nhs-my.sharepoint.com/personal/caroline_finucane_nhs_net/_layouts/15/embed.aspx?UniqueId=d7a8c461-d6b6-4acd-9c58-835a4fccd6b9&embed=%7B%22ust%22%3Atrue%2C%22hv%22%3A%22CopyEmbedCode%22%7D&referrer=StreamWebApp&referrerScenario=EmbedDialog.Create" width="640" height="360" frameborder="0" scrolling="no" allowfullscreen title="Rosies_Journey_Mk6.mp4"></iframe>).
 
+If you can't access this video, please let me know - email caroline.finucane@nhs.net
+
 We're hoping this narrative might be useful for:
 
 - showing commissioners and stakeholders how our products contribute to a real vaccination journey
 - helping new starters understand the VDS ecosystem
 - creating a more engaging alternative to diagrams, slides and product lists
-
-Complex systems are easier to understand when people can see them working in context. By combining visuals, narrative and realistic user scenarios, we hope this demo makes the value of our services easier to understand.   
 
 We do not yet know whether this approach is more effective than traditional presentations and documentation, but we'll share what we learn.

--- a/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
+++ b/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Demo Video: how VDS helps Rosie get vaccinated this autumn"
-description: Over the past year, teams within Vaccination Digital Services have delivered a lot - but for commissioners, stakeholders, and even people working within DPSP, it's not always clear how those pieces fit together or what value they create in practice. We created an end-to-end demo to make that visible.
+description: Why the design team within VDS created an end-to-end demo to make visible how our digital services support the whole journey of getting a vaccination.
 date: 2026-08-03
 tags:
   - demo video
@@ -10,13 +10,13 @@ author:
   - Caroline Finucane
 ---
 
-This demo shows how our products come together to support a person getting an RSV and COVID vaccination in one appointment, using the NHS App.
+Over the past year, teams within Vaccination Digital Services have delivered a lot - but for commissioners, stakeholders, and even people working within DPSP, it's not always clear how those pieces fit together or what value they create in practice. We created an end-to-end demo to make that visible.
+
+This demo video shows how our products come together to support a person getting an RSV and COVID vaccination in one appointment, using the NHS App.
 
 The aim was to help stakeholders understand how we support real campaigns, and give people a clear view of the system as a whole. We included some upcoming features to show where we’re heading.
 
-We centred the journey on RSV, so we could demonstrate a new NHS App feature - Check and Book Vaccinations (currently in private beta) - which supports the RSV vaccination service specifically. [Check and Book Vaccinations](https://design-history.prevention-services.nhs.uk/vaccinations-in-the-app/)
-
-## Watch the demo video
+We centred the journey on RSV, so we could demonstrate a new NHS App feature - [Check and Book Vaccinations](https://design-history.prevention-services.nhs.uk/vaccinations-in-the-app/) (currently in private beta) - which supports the RSV vaccination service specifically. 
 
 [Watch the demo video](https://nhs-my.sharepoint.com/:v:/r/personal/caroline_finucane_nhs_net/Documents/Rosies_Journey_Mk6.mp4?csf=1&web=1&e=tPotYr&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D).
 

--- a/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
+++ b/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
@@ -1,5 +1,5 @@
 ---
-title: Demo Video: how VDS helps Rosie get vaccinated this autumn
+title: "Demo Video: how VDS helps Rosie get vaccinated this autumn"
 description: Over the past year, teams within Vaccination Digital Services have delivered a lot - but for commissioners, stakeholders, and even people working within DPSP, it's not always clear how those pieces fit together or what value they create in practice. We created an end-to-end demo to make that visible.
 date: 2026-08-03
 tags:

--- a/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
+++ b/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
@@ -18,9 +18,7 @@ We centred the journey on RSV, so we could demonstrate a new NHS App feature - C
 
 ## Watch the demo video
 
-Some content.
-
-[LINK TO VIDEO]
+[Watch the demo video](https://nhs-my.sharepoint.com/:v:/r/personal/caroline_finucane_nhs_net/Documents/Rosies_Journey_Mk6.mp4?csf=1&web=1&e=tPotYr&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D).
 
 It was more effort than expected (thank you, UCD team) - but I'm hoping the result now gives us a stronger way to show:
 

--- a/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
+++ b/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
@@ -20,8 +20,6 @@ We centred the journey on RSV so we could demonstrate an NHS App feature - [Chec
 
 ## Watch the demo
 
-[Watch the demo video](https://nhs-my.sharepoint.com/:v:/r/personal/caroline_finucane_nhs_net/Documents/Rosies_Journey_Mk6.mp4?csf=1&web=1&e=tPotYr&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D).
-
 We're hoping this narrative might be useful for:
 
 - showing commissioners and stakeholders how our products contribute to a real vaccination journey

--- a/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
+++ b/app/vaccinations/2026/07/how-rosie-got-vaccinated/index.md
@@ -1,35 +1,34 @@
 ---
-title: This is the title of the post
-description: This description will appear on index pages and when sharing on social media.
-date: 2025-12-01
+title: Demo Video: how VDS helps Rosie get vaccinated this autumn
+description: Over the past year, teams within Vaccination Digital Services have delivered a lot - but for commissioners, stakeholders, and even people working within DPSP, it's not always clear how those pieces fit together or what value they create in practice. We created an end-to-end demo to make that visible.
+date: 2026-08-03
 tags:
-  - add
-  - tags
-  - to help group
-  - related posts
+  - demo video
+  - end to end service
+  - stakeholder engagement
 author:
-  - Your Name
-  - Another Name
-opengraphImage:
-  src: /your-service/2025/12/post-title/image-name.png
-  alt: Alternative text for the lead image
+  - Caroline Finucane
 ---
 
-An intro paragraph which summarises the whole thing.
+This demo shows how our products come together to support a person getting an RSV and COVID vaccination in one appointment, using the NHS App.
 
-## Heading
+The aim was to help stakeholders understand how we support real campaigns, and give people a clear view of the system as a whole. We included some upcoming features to show where we’re heading.
+
+We centred the journey on RSV, so we could demonstrate a new NHS App feature - Check and Book Vaccinations (currently in private beta) - which supports the RSV vaccination service specifically. [Check and Book Vaccinations](https://design-history.prevention-services.nhs.uk/vaccinations-in-the-app/)
+
+## Watch the demo video
 
 Some content.
 
-[A link to another post](/your-service/2025/11/another-post-title/)
+[LINK TO VIDEO]
 
-### Subheading
+It was more effort than expected (thank you, UCD team) - but I'm hoping the result now gives us a stronger way to show:
 
-More content
+- commissioners what we've delivered
+- new starters and other colleagues what we're working on
+- how our services work as a whole
 
-![Alt text for an image](/your-service/2025/12/post-title/image.jpg)
+Because, bringing the journey to life through visuals and narrative makes complex systems easier to understand - and is more engaging for the people we need to influence.
+   
 
-This image has a visible caption:
-
-![Alt text for an image](nhs-logo.png "Caption for the image")
 


### PR DESCRIPTION
Over the past year, teams within Vaccination Digital Services have delivered a lot - but for commissioners, stakeholders, and even people working within DPSP, it's not always clear how those pieces fit together or what value they create in practice.

We created an end-to-end demo to make that visible.

It shows how our products come together to support a person getting an RSV and COVID vaccination in one appointment, using the NHS App. 

The aim was to help stakeholders understand how we support real campaigns, and give people a clear view of the system as a whole. We included some upcoming features to show where we’re heading.

We centred the journey on RSV, so we could demonstrate a new NHS App feature - [Check and Book Vaccinations](https://design-history.prevention-services.nhs.uk/vaccinations-in-the-app/) (currently in private beta) - which supports the RSV vaccination service specifically.

https://github.com/user-attachments/assets/bd45be29-82d0-4ece-9821-01c650296f97

It was more effort than expected (thank you, UCD team!) - but I'm hoping the result now gives us a stronger way to show:

- commissioners what we've delivered 
- new starters and other colleagues what we're working on
- how our services work as a whole

Because, bringing the journey to life through visuals and narrative makes complex systems easier to understand - and is more engaging for the people we need to influence.

